### PR TITLE
Add explanation comments when something breaks

### DIFF
--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -102,6 +102,14 @@ export default class GithubService {
     return response.data.workflow_runs || [];
   }
 
+  public addComment(prNumber: number, body: string) {
+    return this.github.rest.issues.createComment({
+      ...this.repo,
+      issue_number: prNumber,
+      body,
+    });
+  }
+
   public async getWorkflowIdByName(name: string) {
     const workflows = await this.github.rest.actions.listRepoWorkflows({
       ...this.repo,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,12 @@
+export const COMMENTS = {
+  restartWorkflowComment: `CLA: Unexpected error has occurred, please re-run the workflow.
+
+We are sorry for the inconvenience, due to GitHub actions limitations this requires a manual intervention.
+
+There are few ways to do it:
+- Create a new pull request with the same changes.
+- Push an empty commit to the branch.
+- Rebase the branch on top of the latest master might also help.
+
+If the issue persists, please contact the maintainers of this repo.`,
+};

--- a/test/events/issueComment.test.ts
+++ b/test/events/issueComment.test.ts
@@ -3,6 +3,7 @@ import * as coreImport from '@actions/core';
 import {issueComment} from '../../src/events/issueComment';
 import {createContext} from '../mocks';
 import issueCommentPayload from '../fixtures/issue_comment.created.json';
+import {COMMENTS} from '../../src/templates';
 
 const core = {
   ...coreImport,
@@ -17,6 +18,9 @@ function createOctokitMock() {
     rest: {
       reactions: {
         createForIssueComment: jest.fn(),
+      },
+      issues: {
+        createComment: jest.fn(),
       },
       actions: {
         listRepoWorkflows: jest.fn(),
@@ -78,5 +82,88 @@ describe('issue_comment event:', () => {
       repo: issueCommentPayload.repository.name,
       run_id: 'some fake id',
     });
+  });
+  it('should not trigger any actions for other event names', async () => {
+    const context = createContext('pull_request', issueCommentPayload);
+    context.workflow = 'current context';
+
+    await issueComment({
+      claToken,
+      core,
+      octokit,
+      context,
+    });
+
+    expect(octokit.rest.actions.listRepoWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('should add a comment and throw an error if no last run found', async () => {
+    const context = createContext('issue_comment', issueCommentPayload);
+    context.workflow = 'current context';
+
+    octokit.rest.pulls.get.mockReturnValue(
+      Promise.resolve({data: {head: {ref: 'feature-branch'}}}),
+    );
+
+    octokit.rest.actions.listRepoWorkflows.mockReturnValue(
+      Promise.resolve({data: {workflows: [{name: context.workflow}]}}),
+    );
+
+    octokit.rest.actions.listWorkflowRuns.mockReturnValue(
+      Promise.resolve({data: {workflow_runs: []}}),
+    );
+
+    await expect(
+      issueComment({
+        claToken,
+        core,
+        octokit,
+        context,
+      }),
+    ).rejects.toThrowError(/Cannot find last run for the workflow/);
+
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith({
+      body: COMMENTS.restartWorkflowComment,
+      issue_number: context.issue.number,
+      owner: issueCommentPayload.repository.owner.login,
+      repo: issueCommentPayload.repository.name,
+    });
+  });
+
+  it('should add a success reaction if the recent workflow run was successful', async () => {
+    const context = createContext('issue_comment', issueCommentPayload);
+    context.workflow = 'current context';
+
+    octokit.rest.pulls.get.mockReturnValue(
+      Promise.resolve({data: {head: {ref: 'feature-branch'}}}),
+    );
+
+    octokit.rest.actions.listRepoWorkflows.mockReturnValue(
+      Promise.resolve({data: {workflows: [{name: context.workflow}]}}),
+    );
+
+    octokit.rest.actions.listWorkflowRuns.mockReturnValue(
+      Promise.resolve({data: {workflow_runs: [{id: 'some fake id'}]}}),
+    );
+
+    octokit.rest.actions.getWorkflowRun.mockReturnValue(
+      Promise.resolve({data: {conclusion: 'success'}}),
+    );
+
+    await issueComment({
+      claToken,
+      core,
+      octokit,
+      context,
+    });
+
+    expect(octokit.rest.reactions.createForIssueComment).toHaveBeenCalledWith({
+      comment_id: issueCommentPayload.comment.id,
+      content: '+1',
+      owner: issueCommentPayload.repository.owner.login,
+      repo: issueCommentPayload.repository.name,
+    });
+
+    expect(octokit.rest.actions.reRunWorkflow).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Sometimes we can't restart the workflow because it doesn't exist or was run more than 30 days before.

We can't just rewrite the check that was added by "pr.open/synchronize" event because of permissions.

In such cases we ask user to do manual tweaking on the PR.