### PR TITLE
Add additional detail to messaging

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 export const config = {
   errorMessages: {
     requestKnownUsers:
-      '{{usernames}}: [Sign the CLA]({{claUrl}}) to have your PR reviewed.',
+      '{{usernames}}: [Sign the CLA]({{claUrl}}) and comment "I have signed the CLA!" to re-run the checks and have your PR reviewed.',
     requestUnknownUsers:
       '{{emails}}: Connect your email address with a GitHub account and [sign the CLA]({{claUrl}}) to have your PR reviewed.',
     welcome:


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shopify-cla-action/issues/28

# Changes

- Add additional detail to the messaging of the message when the CLA needs to be signed.